### PR TITLE
Fix runtime error during push zero size data to buffer with dataSize equals 0

### DIFF
--- a/CircularBuffer.c
+++ b/CircularBuffer.c
@@ -58,6 +58,9 @@ size_t CircularBufferGetDataSize(CircularBuffer cBuf)
 
 void CircularBufferPush(CircularBuffer cBuf,void *src, size_t length)
 {
+    if(length == 0)
+        return;
+
     size_t writableLen = length;
     void *pSrc = src;
     


### PR DESCRIPTION
An example for calling an error:
    
```
CircularBuffer cb = CircularBufferCreate(8);
char *a = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
char b[128];
CircularBufferPush(cb, a, 0);
```